### PR TITLE
Feature/api updating long drive match data

### DIFF
--- a/Multiplayer.API/Controllers/LongdriveController.cs
+++ b/Multiplayer.API/Controllers/LongdriveController.cs
@@ -39,6 +39,17 @@ namespace Multiplayer.API.Controllers
             return result;
         }
 
+        // GET: Get random long drive data filtered by map name
+        [HttpGet("single/{mapId:int}")]
+        public async Task<ActionResult<LongDriveModel>> GetRandomLongdriveByMap(int mapId)
+        {
+            var result = await _longdriveService.GetRandomByMapAsync(mapId);
+            if (result is null)
+                return NotFound();
+
+            return result;
+        }
+
         // POST: Create new long drive data
         [HttpPost]
         public async Task<ActionResult> Post(LongDriveModel newLongdrive)

--- a/Multiplayer.API/Models/LongDriveModel.cs
+++ b/Multiplayer.API/Models/LongDriveModel.cs
@@ -10,6 +10,7 @@ namespace Multiplayer.API.Models
         [BsonRepresentation(BsonType.ObjectId)]
         public string? id { get; set; }
         public string UserId { get; set; } = null!;
+        public int MapId { get; set; }
         public PlayerTurnsData[] PlayerTurnsData { get; set; } = null!;
     }
 }

--- a/Multiplayer.API/Services/LongdriveService.cs
+++ b/Multiplayer.API/Services/LongdriveService.cs
@@ -37,6 +37,20 @@ namespace Multiplayer.API.Services
             return await _database.Find(new BsonDocument()).Skip(skip).Limit(1).FirstOrDefaultAsync();
         }
 
+        // Get random long drive data filtered by map ID
+        public async Task<LongDriveModel?> GetRandomByMapAsync(int mapId)
+        {
+            var filter = Builders<LongDriveModel>.Filter.Eq(i => i.MapId, mapId);
+            var count = await _database.CountDocumentsAsync(filter);
+            if (count == 0)
+                return null;
+
+            var random = new Random();
+            var skip = random.Next(0, (int)count);
+
+            return await _database.Find(filter).Skip(skip).Limit(1).FirstOrDefaultAsync();
+        }
+
         // Post new long drive data
         public async Task CreateAsync(LongDriveModel newLongdrive) =>
             await _database.InsertOneAsync(newLongdrive);


### PR DESCRIPTION
PR Description: Addition of Map ID and Random Long Drive Data Retrieval by ID
Summary:
This pull request introduces the following key changes:

Addition of MapId Field:

A new MapId field (integer) has been added to the LongDriveModel to replace the MapName field, making the map system more scalable and flexible.
The MapId will be used to associate each long drive match with a specific map, simplifying future updates and making it easier to reference maps in a consistent manner.

Retrieval of Random Long Drive Data by MapId:

A new API endpoint has been added to retrieve a random long drive match filtered by MapId.
The method retrieves a random document from the MongoDB collection where the MapId matches the provided value, ensuring that players are matched to games on the same map.